### PR TITLE
fix : How to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Julia ≥ 1.6.
 
 ## How to install
 ```julia
-pkg> add https://github.com/paraynaud/PartitionedStructures.jl
+pkg> add PartitionedStructures
 pkg> test PartitionedStructures
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ Julia ≥ 1.6.
 
 ## How to install
 ```julia
-pkg> add https://github.com/paraynaud/PartitionedStructures.jl
+pkg> add PartitionedStructures
 pkg> test PartitionedStructures
 ```
 


### PR DESCRIPTION
Since the package is registered, the url is no needed to `add` the package.