### PR TITLE
use push_preview = true in deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,5 +63,6 @@ makedocs(
 
 deploydocs(
   repo = "github.com/JuliaSmoothOptimizers/PartitionedStructures.jl.git",
+  push_preview = true,
   devbranch = "main",
 )


### PR DESCRIPTION
With this change, a new workflow named "documenter/deploy" appears in the list of checks when the docs have finished building.
Clicking on "details" takes you to the docs resulting from the pull request.