### PR TITLE
PCS update

### DIFF
--- a/src/P_mat/elemental_em.jl
+++ b/src/P_mat/elemental_em.jl
@@ -17,7 +17,7 @@ It has fields:
 
 * `indices`: indices of elemental variables;
 * `nie`: elemental size (`=length(indices)`);
-* `Bie`: the elemental matrix`::Symmetric{T, Matrix{T}}`;
+* `Bie::Symmetric{T, Matrix{T}}`: the elemental matrix;
 * `counter`: counts how many update the elemental matrix goes through from its allocation;
 * `convex`: if `Elemental_em` is by default update with BFGS or SR1.
 """

--- a/src/P_mat/elemental_em.jl
+++ b/src/P_mat/elemental_em.jl
@@ -32,7 +32,8 @@ end
 @inline (==)(eem1::Elemental_em{T}, eem2::Elemental_em{T}) where {T} =
   (get_nie(eem1) == get_nie(eem2)) &&
   (get_Bie(eem1) == get_Bie(eem2)) &&
-  (get_indices(eem1) == get_indices(eem2))
+  (get_indices(eem1) == get_indices(eem2)) &&
+  (get_convex(eem1) == get_convex(eem2))
 @inline copy(eem::Elemental_em{T}) where {T} = Elemental_em{T}(
   copy(get_nie(eem)),
   copy(get_indices(eem)),

--- a/src/P_mat/elemental_em.jl
+++ b/src/P_mat/elemental_em.jl
@@ -37,14 +37,14 @@ end
   copy(get_nie(eem)),
   copy(get_indices(eem)),
   copy(get_Bie(eem)),
-  copy(get_cem(eem)),
+  Counter_elt_mat(),
   copy(get_convex(eem))
 )
 @inline similar(eem::Elemental_em{T}) where {T} = Elemental_em{T}(
   copy(get_nie(eem)),
   copy(get_indices(eem)),
   similar(get_Bie(eem)),
-  copy(get_cem(eem)),
+  Counter_elt_mat(),
   copy(get_convex(eem))
 )
 

--- a/src/P_mat/elemental_pm.jl
+++ b/src/P_mat/elemental_pm.jl
@@ -119,10 +119,12 @@ identity_epm(
   N::Int = length(element_variables),
   n::Int = max_indices(element_variables),
   T = Float64,
-) = identity_epm(element_variables, N, n; T = T)
+  convex_vector::Vector{Bool}=zeros(Bool, N)
+) = identity_epm(element_variables, N, n; T, convex_vector)
 
-function identity_epm(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64)
-  eem_set = map((elt_var -> create_id_eem(elt_var; T = T)), element_variables)
+function identity_epm(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64, convex_vector::Vector{Bool}=zeros(Bool, N))
+  # eem_set = map((elt_var -> create_id_eem(elt_var; T = T)), element_variables)
+  eem_set = map((i -> create_id_eem(element_variables[i]; T = T, bool=convex_vector[i])), 1:length(element_variables))
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
   component_list = map(i -> Vector{Int}(undef, 0), [1:n;])
@@ -138,8 +140,8 @@ end
 Return a partitionned matrix of type `T` of `N` identity elemental element-matrices.
 Each elemental element-matrix is of size `nie` with randoms positions.
 """
-function identity_epm(N::Int, n::Int; T = Float64, nie::Int = 5)
-  eem_set = map(i -> identity_eem(nie; T = T, n = n), [1:N;])
+function identity_epm(N::Int, n::Int; T = Float64, nie::Int = 5, convex_vector::Vector{Bool}=zeros(Bool, N))
+  eem_set = map(i -> identity_eem(nie; T = T, n = n, bool=convex_vector[i]), [1:N;])
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
   component_list = map(i -> Vector{Int}(undef, 0), [1:n;])

--- a/src/P_mat/elemental_pm.jl
+++ b/src/P_mat/elemental_pm.jl
@@ -123,7 +123,6 @@ identity_epm(
 ) = identity_epm(element_variables, N, n; T, convex_vector)
 
 function identity_epm(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64, convex_vector::Vector{Bool}=zeros(Bool, N))
-  # eem_set = map((elt_var -> create_id_eem(elt_var; T = T)), element_variables)
   eem_set = map((i -> create_id_eem(element_variables[i]; T = T, bool=convex_vector[i])), 1:length(element_variables))
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
@@ -256,7 +255,6 @@ function part_mat(; n::Int = 9, T = Float64, nie::Int = 5, overlapping::Int = 1,
   N = length(eem_set)
   epm = Elemental_pm{T}(N, n, eem_set, spm, L, component_list, no_perm)
   initialize_component_list!(epm)
-  # set_spm!(epm)
   return epm
 end
 

--- a/src/P_mat/elt_mat.jl
+++ b/src/P_mat/elt_mat.jl
@@ -4,7 +4,7 @@ using ..Acronyms
 using ..M_abstract_element_struct
 
 export Elt_mat, DenseEltMat, LOEltMat
-export get_Bie, get_counter_elt_mat, get_cem, get_current_untouched, get_index
+export get_Bie, get_counter_elt_mat, get_cem, get_current_untouched, get_index, get_convex
 
 export Counter_elt_mat
 export update_counter_elt_mat!, iter_info, total_info
@@ -61,6 +61,8 @@ Return index: the number of the last partitioned-updates that did not update the
 If the last partitioned-update updates `elt_mat` then `index` will be equal to `0`.
 """
 @inline get_index(elt_mat::T) where {T <: Elt_mat} = get_current_untouched(elt_mat.counter)
+
+@inline get_convex(elt_mat::Elt_mat) = elt_mat.convex
 
 Counter_elt_mat() = Counter_elt_mat(0, 0, 0, 0, 0, 0)
 copy(cem::Counter_elt_mat) = Counter_elt_mat(

--- a/src/PartitionedStructures.jl
+++ b/src/PartitionedStructures.jl
@@ -60,6 +60,7 @@ export update, update!
 export PBFGS_update!, PBFGS_update
 export PSR1_update!, PSR1_update
 export PSE_update, PSE_update!
+export PCS_update, PCS_update!
 export PLBFGS_update, PLBFGS_update!
 export PLSR1_update, PLSR1_update!
 export PLSE_update, PLSE_update!

--- a/src/methods/link.jl
+++ b/src/methods/link.jl
@@ -53,7 +53,7 @@ end
 Create an elemental partitioned quasi-Newton operator `epm` with the same partitioned structure than `epv`.
 Each element-matrix of `epm` is set with an identity matrix of suitable size.
 """
-function epm_from_epv(epv::T) where {Y <: Number, T <: Elemental_pv{Y}}
+function epm_from_epv(epv::T; convex_vector::Vector{Bool}=zeros(Bool, N)) where {Y <: Number, T <: Elemental_pv{Y}}
   N = get_N(epv)
   n = get_n(epv)
   eelo_indices_set = Vector{Vector{Int}}(undef, N)
@@ -62,7 +62,7 @@ function epm_from_epv(epv::T) where {Y <: Number, T <: Elemental_pv{Y}}
     indices = get_indices(eesi)
     eelo_indices_set[i] = indices
   end
-  epm = identity_epm(eelo_indices_set, N, n; T = Y)
+  epm = identity_epm(eelo_indices_set, N, n; T = Y, convex_vector)
   return epm
 end
 

--- a/src/methods/link.jl
+++ b/src/methods/link.jl
@@ -53,7 +53,7 @@ end
 Create an elemental partitioned quasi-Newton operator `epm` with the same partitioned structure than `epv`.
 Each element-matrix of `epm` is set with an identity matrix of suitable size.
 """
-function epm_from_epv(epv::T; convex_vector::Vector{Bool}=zeros(Bool, N)) where {Y <: Number, T <: Elemental_pv{Y}}
+function epm_from_epv(epv::T; convex_vector::Vector{Bool}=zeros(Bool, get_N(epv))) where {Y <: Number, T <: Elemental_pv{Y}}
   N = get_N(epv)
   n = get_n(epv)
   eelo_indices_set = Vector{Vector{Int}}(undef, N)

--- a/src/methods/part_mat_interface.jl
+++ b/src/methods/part_mat_interface.jl
@@ -52,6 +52,7 @@ The PSE update is run by default, you can apply a PBFGS or a PSR1 update with th
   (name == :pse) && PSE_update!(epm, epv_y, epv_s; kwargs...)
   (name == :pbfgs) && PBFGS_update!(epm, epv_y, epv_s; kwargs...)
   (name == :psr1) && PSR1_update!(epm, epv_y, epv_s; kwargs...)
+  (name == :pcs) && PCS_update!(epm, epv_y, epv_s; kwargs...)
   return epm
 end
 

--- a/test/P_mat/em.jl
+++ b/test/P_mat/em.jl
@@ -5,8 +5,10 @@ using PartitionedStructures.M_elt_mat, PartitionedStructures.ModElemental_em
   T = Float64
   nie = 5
   n = 20
-  eem1 = identity_eem(nie; T = T, n = n)
-  eem2 = ones_eem(nie; T = T, n = n)
+  eem1 = identity_eem(nie; T = T, n = n, bool=true)
+  eem2 = ones_eem(nie; T = T, n = n, bool=false)
+  @test eem1.convex == true
+  @test eem2.convex == false
 
   cp_eem1 = copy(eem1)
   p = [1:n;]

--- a/test/P_mat/plm.jl
+++ b/test/P_mat/plm.jl
@@ -96,11 +96,11 @@ end
 end
 
 @testset "eplo_bfgs PartiallySeparableNLPModels" begin
-  N = 15
-  n = 20
-  nie = 5
-  s = rand(n)
-  element_variables = vcat(map((i -> rand(1:n, nie)), 1:(N - 1)), [[4, 8, 12, 16, 20]])
+  N = 4
+  n = 8
+  element_variables = [ [1,2,5,7], [3,6,7,8], [2,4,6,8], [1,3,5,6,7]]
+  s = rand(n)  
+  
   eplo = identity_eplo_LBFGS(element_variables, N, n)
   @test eplo == identity_eplo_LBFGS(element_variables)
   epv = epv_from_epm(eplo)

--- a/test/P_mat/pm.jl
+++ b/test/P_mat/pm.jl
@@ -20,7 +20,8 @@ using PartitionedStructures.M_abstract_part_struct
   @test sum(Matrix(pm2.spm)) == N * nie^2
   @test sum(Matrix(pm1.spm)) == N * nie
 
-  # @test (@allocated reset_spm!(pm1)) == 0
+  reset_spm!(pm1)
+  @test (@allocated reset_spm!(pm1)) == 0
 
   set_spm!(pm1)
   original_spm1 = copy(get_spm(pm1))
@@ -45,11 +46,10 @@ end
   N = 4
   n = 8
   element_variables = [ [1,2,5,7], [3,6,7,8], [2,4,6,8], [1,3,5,6,7]]
-  bools = [true, true, true, true]
-  identity_epm(element_variables, N, n)
-  epm_true = identity_epm(element_variables; convex_vector=bools)
-
+  bools = [true, true, true, true]  
+  
   epm = identity_epm(element_variables)
+  epm_true = identity_epm(element_variables; convex_vector=bools)
   
   @test identity_epm(element_variables, N, n) == identity_epm(element_variables)
   @test mapreduce(eem -> eem.convex==false, &, epm.eem_set)
@@ -60,9 +60,13 @@ end
   @test epm == copy_epm
   @test check_epv_epm(epm, copy_epm)
   @test check_epv_epm(epm, similar_epm)
+  @test check_epv_epm(epm, epm_true)
 
   @test full_check_epv_epm(epm, copy_epm)
   @test full_check_epv_epm(epm, similar_epm)
+  @test full_check_epv_epm(epm, epm_true)
+
   @test epm == copy_epm
   @test epm != similar_epm
+  @test epm != epm_true
 end

--- a/test/P_mat/pm.jl
+++ b/test/P_mat/pm.jl
@@ -10,6 +10,8 @@ using PartitionedStructures.M_abstract_part_struct
   n = 10
   nie = 3
   pm1 = identity_epm(N, n; nie = nie)
+  @test mapreduce(eem -> eem.convex==false, &, pm1.eem_set)
+
   set_spm!(pm1)
   pm2 = ones_epm(N, n; nie = nie)
   set_spm!(pm2)
@@ -18,7 +20,7 @@ using PartitionedStructures.M_abstract_part_struct
   @test sum(Matrix(pm2.spm)) == N * nie^2
   @test sum(Matrix(pm1.spm)) == N * nie
 
-  @test (@allocated reset_spm!(pm1)) == 0
+  # @test (@allocated reset_spm!(pm1)) == 0
 
   set_spm!(pm1)
   original_spm1 = copy(get_spm(pm1))
@@ -40,13 +42,17 @@ using PartitionedStructures.M_abstract_part_struct
 end
 
 @testset "pm PartiallySeparableNLPModels" begin
-  N = 15
-  n = 20
-  nie = 5
-  element_variables = vcat(map((i -> rand(1:n, nie)), 1:(N - 1)), [[4, 8, 12, 16, 20]])
+  N = 4
+  n = 8
+  element_variables = [ [1,2,5,7], [3,6,7,8], [2,4,6,8], [1,3,5,6,7]]
+  bools = [true, true, true, true]
   identity_epm(element_variables, N, n)
+  epm_true = identity_epm(element_variables; convex_vector=bools)
+
   epm = identity_epm(element_variables)
+  
   @test identity_epm(element_variables, N, n) == identity_epm(element_variables)
+  @test mapreduce(eem -> eem.convex==false, &, epm.eem_set)
 
   copy_epm = copy(epm)
   similar_epm = similar(epm)

--- a/test/others/partitionedQuasiNewton.jl
+++ b/test/others/partitionedQuasiNewton.jl
@@ -11,6 +11,8 @@ using PartitionedStructures.PartitionedQuasiNewton
   s = ones(n)
   epm_B11 = PBFGS_update(epm_B1, epv_y1, s)
   epm_B12 = PSR1_update(epm_B1, epv_y1, s)
+  epm_B13 = PSE_update(epm_B1, epv_y1, s)
+  
 
   @test Matrix(epm_B1) == transpose(Matrix(epm_B1))
   @test Matrix(epm_B11) != Matrix(epm_B1)
@@ -43,5 +45,21 @@ using PartitionedStructures.PartitionedQuasiNewton
       epm_B11 = PBFGS_update(epm_B1, epv_y1, s)
       @test mapreduce((x -> x > 0), my_and, eigvals(Matrix(epm_B11))) #test positive eigensvalues
     end
+  end
+
+  @testset "PSC update" begin
+    N = 4
+    n = 8
+    element_variables = [ [1,2,5,7], [3,6,7,8], [2,4,6,8], [1,3,5,6,7]]
+    bools = [true, false, false, true]  
+    
+    epm = identity_epm(element_variables; convex_vector=bools)
+    
+    epv_y = epv_from_epm(epm)
+    s = ones(n)
+    
+    epmBFGS = PBFGS_update(epm, epv_y, s)
+    epmCS = PCS_update(epm, epv_y, s)
+    @test Matrix(epmBFGS) != Matrix(epmCS)
   end
 end


### PR DESCRIPTION
- add `convex::Bool` field to elemental element matrix 
- PCS update that update with BFGS if  `convex`with SR1 otherwise
- adapt usual elemental element and partitioned matrix definitions
- tests 