### PR TITLE
allocation free for partitioned updates

### DIFF
--- a/src/P_mat/elt_mat.jl
+++ b/src/P_mat/elt_mat.jl
@@ -4,7 +4,8 @@ using ..Acronyms
 using ..M_abstract_element_struct
 
 export Elt_mat, DenseEltMat, LOEltMat
-export get_Bie, get_counter_elt_mat, get_cem, get_current_untouched, get_index, get_convex
+export get_Bie, get_Bsr
+export get_counter_elt_mat, get_cem, get_current_untouched, get_index, get_convex
 
 export Counter_elt_mat
 export update_counter_elt_mat!, iter_info, total_info
@@ -39,6 +40,14 @@ end
 Return the element-matrix `elt_mat.Bie`.
 """
 @inline get_Bie(elt_mat::T) where {T <: Elt_mat} = elt_mat.Bie
+
+"""
+    get_Bsr(elt_mat::T) where T <: Elt_mat
+
+Return the temporary vector `elt_mat._Bsr`.
+"""
+@inline get_Bsr(elt_mat::T) where {T <: Elt_mat} = elt_mat._Bsr
+
 
 """
     cem = get_counter_elt_mat(elt_mat::T) where T <: Elt_mat

--- a/src/methods/PartitionedQuasiNewton.jl
+++ b/src/methods/PartitionedQuasiNewton.jl
@@ -64,7 +64,8 @@ function PBFGS_update!(
     si = get_vec(get_eev_set(epv_s, i))
     yi = get_vec(get_eev_set(epv_y, i))
     index = get_index(eemi)
-    update = BFGS!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
+    Bs = get_Bsr(get_eem_set(epm_B, i))
+    update = BFGS!(si, yi, Bi; index = index, Bs, kwargs...) # return 0 or 1
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)
   end
@@ -124,8 +125,9 @@ function PSR1_update!(
     Bi = get_Bie(eemi)
     si = get_vec(get_eev_set(epv_s, i))
     yi = get_vec(get_eev_set(epv_y, i))
-    index = get_index(eemi)
-    update = SR1!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
+    r = get_Bsr(get_eem_set(epm_B, i))
+    index = get_index(eemi)    
+    update = SR1!(si, yi, Bi; index = index, r, kwargs...) # return 0 or 1
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)
   end
@@ -186,8 +188,9 @@ function PSE_update!(
     Bi = get_Bie(eemi)
     si = get_vec(get_eev_set(epv_s, i))
     yi = get_vec(get_eev_set(epv_y, i))
+    Bs_r = get_Bsr(get_eem_set(epm_B, i))
     index = get_index(eemi)
-    update = SE!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
+    update = SE!(si, yi, Bi; index = index, Bs_r, kwargs...) # return 0 or 1
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)
   end

--- a/src/methods/PartitionedQuasiNewton.jl
+++ b/src/methods/PartitionedQuasiNewton.jl
@@ -187,7 +187,7 @@ function PSE_update!(
     si = get_vec(get_eev_set(epv_s, i))
     yi = get_vec(get_eev_set(epv_y, i))
     index = get_index(eemi)
-    update = SE!(si, yi, Bi, Bi; index = index, kwargs...) # return 0 or 1
+    update = SE!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)
   end

--- a/src/methods/PartitionedQuasiNewton.jl
+++ b/src/methods/PartitionedQuasiNewton.jl
@@ -64,7 +64,7 @@ function PBFGS_update!(
     si = get_vec(get_eev_set(epv_s, i))
     yi = get_vec(get_eev_set(epv_y, i))
     index = get_index(eemi)
-    update = BFGS!(si, yi, Bi, Bi; index = index, kwargs...) # return 0 or 1
+    update = BFGS!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)
   end
@@ -125,7 +125,7 @@ function PSR1_update!(
     si = get_vec(get_eev_set(epv_s, i))
     yi = get_vec(get_eev_set(epv_y, i))
     index = get_index(eemi)
-    update = SR1!(si, yi, Bi, Bi; index = index, kwargs...) # return 0 or 1
+    update = SR1!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)
   end
@@ -250,9 +250,9 @@ function PCS_update!(
     index = get_index(eemi)
     convex = get_convex(eemi)
     if convex
-      update = BFGS!(si, yi, Bi, Bi; index = index, kwargs...) # return 0 or 1
+      update = BFGS!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
     else
-      update = SR1!(si, yi, Bi, Bi; index = index, kwargs...) # return 0 or 1
+      update = SR1!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
     end
     cem = get_cem(eemi)
     update_counter_elt_mat!(cem, update)

--- a/test/others/update.jl
+++ b/test/others/update.jl
@@ -179,10 +179,10 @@ end
   B_PBFGS2 = Matrix(partitioned_matrix)
 
   norm(B_BFGS1 * s1 - y1)
-  @test norm(B_BFGS1 * s1 - y1) == 0.0
+  @test isapprox(norm(B_BFGS1 * s1 - y1), 0.0; atol=1e-10)
 
   norm(B_PBFGS1 * s1 - y1)
-  @test norm(B_PBFGS1 * s1 - y1) == 0.0
+  @test isapprox(norm(B_PBFGS1 * s1 - y1), 0.0)
 
   partitioned_matrix_PSR1 = epm_from_epv(partitioned_gradient_x0)
   partitioned_matrix_PSE = copy(partitioned_matrix_PSR1)
@@ -196,10 +196,10 @@ end
   B_PLBFGS = update(partitioned_linear_operator_PLBFGS, partitioned_gradient_difference, s1)
   B_PLSE = update(partitioned_linear_operator_PLSE, partitioned_gradient_difference, s1)
 
-  @test norm(B_PSR1 * s1 - y1) == 0.0
-  @test norm(B_PSE * s1 - y1) == 0.0
-  @test norm(B_PLBFGS * s1 - y1) == 0.0
-  @test norm(B_PLSE * s1 - y1) == 0.0
+  @test isapprox(norm(B_PSR1 * s1 - y1), 0.0)
+  @test isapprox(norm(B_PSE * s1 - y1), 0.0)
+  @test isapprox(norm(B_PLBFGS * s1 - y1), 0.0)
+  @test isapprox(norm(B_PLSE * s1 - y1), 0.0)
 
   # There is also a PLSR1 approximation, but is not fullt working since there is some issues with LSR1Operator
   partitioned_linear_operator_PLSR1 = eplo_lsr1_from_epv(partitioned_gradient_x0)

--- a/test/others/utils.jl
+++ b/test/others/utils.jl
@@ -10,8 +10,8 @@ using PartitionedStructures.Utils
 
   @testset "BFGS" begin
     n = 10
-    B = reshape([(i == j ? 1.0 : 0.0) for i = 1:n for j = 1:n], n, n)
-    B_x2 = (x -> 2 * x).(reshape([(i == j ? 1.0 : 0.0) for i = 1:n for j = 1:n], n, n))
+    B = [(i == j ? 1.0 : 0.0) for i = 1:n, j = 1:n]
+    B_x2 = (x -> 2 * x).([(i == j ? 1.0 : 0.0) for i = 1:n, j = 1:n])
     s = rand(n)
     y = rand(n)
 


### PR DESCRIPTION
Make BFGS/SR1/SE/CS alocation free ( 5 arg mul!).

It will add a temporary vector for each element matrices, to define an alllocation free updzte (ex: `Bs` for BFGS, `r` for SR1).
