### PR TITLE
allocation free partitioned matrix vector product

### DIFF
--- a/src/PartitionedStructures.jl
+++ b/src/PartitionedStructures.jl
@@ -51,7 +51,7 @@ export initialize_component_list!
 export full_check_epv_epm
 export epm_from_epv, eplo_lbfgs_from_epv, eplo_lose_from_epv, eplo_lsr1_from_epv
 export create_epv_eplo, epv_from_eplo, epv_from_epm
-export mul_epm_vector, mul_epm_vector!, mul_epm_epv
+export mul_epm_vector, mul_epm_vector!, mul_epm_epv, mul_epm_epv!
 export Counter_elt_mat, string_counters_iter, string_counters_total
 export prod_part_vectors
 

--- a/src/methods/link.jl
+++ b/src/methods/link.jl
@@ -135,18 +135,8 @@ The method uses temporary the $(_epv).
 The method returns `result`, a vector similar to `x`.
 """
 function mul_epm_vector(epm::T, x::Vector{Y}) where {Y <: Number, T <: Part_mat{Y}}
-  epv = epv_from_epm(epm)
-  return mul_epm_vector(epm, epv, x)
-end
-
-function mul_epm_vector(
-  epm::T,
-  epv::Elemental_pv{Y},
-  x::Vector{Y},
-) where {Y <: Number, T <: Part_mat{Y}}
   res = similar(x)
-  mul_epm_vector!(res, epm, epv, x)
-  return res
+  return mul_epm_vector!(res, epm, x)
 end
 
 """
@@ -159,20 +149,11 @@ The result is stored in `res`, a vector similar to `x`.
 """
 function mul_epm_vector!(res::Vector{Y}, epm::T, x::Vector{Y}) where {Y <: Number, T <: Part_mat{Y}}
   epv = epv_from_epm(epm)
-  mul_epm_vector!(res, epm, epv, x)
-  return res
-end
-
-function mul_epm_vector!(
-  res::Vector{Y},
-  epm::T,
-  epv::Elemental_pv{Y},
-  x::Vector{Y},
-) where {Y <: Number, T <: Part_mat{Y}}
   epv_from_v!(epv, x)
-  mul_epm_epv!(epv, epm, epv)
-  build_v!(epv)
-  res .= get_v(epv)
+  epv_res = similar(epv)
+  mul_epm_epv!(epv_res, epm, epv)
+  build_v!(epv_res)
+  res .= get_v(epv_res)
   return res
 end
 
@@ -204,7 +185,8 @@ function mul_epm_epv!(
   for i = 1:N
     Bie = get_ee_struct_Bie(epm, i)
     vie = get_eev_value(epv, i)
-    set_eev!(epv_res, i, Bie * vie)
+    res_i = get_eev_value(epv_res, i)
+    mul!(res_i, Bie, vie, 1., 0.)
   end
   return epv_res
 end


### PR DESCRIPTION
The following script compare the partitioned matrix vector product:

```julia 
#main
BenchmarkTools.Trial: 336 samples with 1 evaluation.
 Range (min … max):  11.610 ms … 22.156 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.579 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   14.884 ms ±  3.455 ms  ┊ GC (mean ± σ):  0.01% ± 0.18%
    █▅                
  ▆███▆█▆▃▃▃▂▂▂▃▃▃▃▃▁▂▃▂▁▂▃▃▂▂▂▁▁▃▂▁▁▃▂▁▃▃▃▃▃▃▃▃▄▆▇▅▄▄▃▃▂▂▁▂▂ ▃
  11.6 ms         Histogram: frequency by time        21.6 ms <
 Memory estimate: 148.44 KiB, allocs estimate: 500.

# pray-partitioned-prod
BenchmarkTools.Trial: 428 samples with 1 evaluation.
 Range (min … max):  10.677 ms …  18.350 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     11.746 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.673 ms ± 564.442 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
         ▁ ▁            ▄▁▄▅▄█▂▂▃
  ▃▄▂▄▆▄▆█▇█▇█▄▅▃▃▂▃▂▄▇███████████▇█▆▅▄▃▃▂▃▃▁▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▃ ▄
  10.7 ms         Histogram: frequency by time         13.2 ms <
 Memory estimate: 0 bytes, allocs estimate: 0.

```
The change is not significative, ut there is not allocation anymore.

from the script:
```julia
using PartitionedStructures
using BenchmarkTools
using LinearAlgebra
using StatsBase

N = 500
n = 200
ni = 30
element_variables = map(i -> sample(1:n, ni, replace = false) ,1:N)

epm = identity_epm(element_variables)
epv = epv_from_epm(epm)
epv_y = similar(epv)
epv_from_v!(epv_y, ones(n))
epv_res = similar(epv)

@benchmark PartitionedStructures.mul_epm_epv!(epv_res, epm, epv)
```