### PR TITLE
Partitioned `broadcast` + Krylov support

### DIFF
--- a/src/P_vec/elemental_ev.jl
+++ b/src/P_vec/elemental_ev.jl
@@ -6,7 +6,6 @@ using ..M_abstract_element_struct, ..M_elt_vec, ..Utils
 
 import Base.==, Base.copy, Base.similar
 import Base:-, +, *
-import Base.broadcast!
 
 export Elemental_elt_vec
 export ones_eev, new_eev, specific_ones_eev
@@ -42,12 +41,6 @@ end
 (*)(eev::Elemental_elt_vec{T}, val::Y) where {T, Y} = Elemental_elt_vec{T}(Vector{T}(val .* get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
 (*)(val::Y, eev::Elemental_elt_vec{T}) where {T, Y} = Elemental_elt_vec{T}(Vector{T}(val .* get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
 (*)(eev::Elemental_elt_vec{T}, val::Y) where {T, Y} = Elemental_elt_vec{T}(Vector{T}(val .* get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
-
-# function broadcast!(f::Function, eev::Elemental_elt_vec{T}, As...) where {T}
-#   _As = map(as -> as[get_indices(eev)], As)
-#   broadcast!(f, get_vec(eev), _As...)
-#   return eev
-# end
 
 """
     eem = new_eev(nᵢ::Int; T=Float64, n=nᵢ^2)

--- a/src/P_vec/elemental_ev.jl
+++ b/src/P_vec/elemental_ev.jl
@@ -16,10 +16,10 @@ export create_eev, eev_from_sparse_vec, sparse_vec_from_eev
 """
     Elemental_elt_vec{T} <: Elt_vec{T}
 
-Represent an elemental element-vector.
-`indices` retains the indices of the elemental variables.
-`nie` is the elemental size (`=length(indices)`).
-`vec` is the current value of the elemental element vector.
+Represent an elemental element-vector:
+- `indices` retains the indices of the elemental variables;
+- `nie` is the elemental size (`=length(indices)`);
+- `vec` is the current value of the elemental element vector.
 """
 mutable struct Elemental_elt_vec{T} <: Elt_vec{T}
   vec::Vector{T} # length(vec)==nᵢᴱ
@@ -36,9 +36,9 @@ end
 @inline copy(eev::Elemental_elt_vec{T}) where {T} =
   Elemental_elt_vec{T}(Vector{T}(get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
 
-(-)(eev::Elemental_elt_vec{T}) where {T} = Elemental_elt_vec{T}(Vector{T}(- get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
-(-)(eev1::Elemental_elt_vec{T}, eev2::Elemental_elt_vec{T})  where {T} = Elemental_elt_vec{T}(Vector{T}(get_vec(eev1) - get_vec(eev2)), Vector{Int}(get_indices(eev1)), get_nie(eev1))
-(+)(eev1::Elemental_elt_vec{T}, eev2::Elemental_elt_vec{T})  where {T} = Elemental_elt_vec{T}(Vector{T}(get_vec(eev1) + get_vec(eev2)), Vector{Int}(get_indices(eev1)), get_nie(eev1))
+(-)(eev::Elemental_elt_vec{T}) where {T} = Elemental_elt_vec{T}(Vector{T}(.- get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
+(-)(eev1::Elemental_elt_vec{T}, eev2::Elemental_elt_vec{T}) where {T} = Elemental_elt_vec{T}(Vector{T}(get_vec(eev1) .- get_vec(eev2)), Vector{Int}(get_indices(eev1)), get_nie(eev1))
+(+)(eev1::Elemental_elt_vec{T}, eev2::Elemental_elt_vec{T}) where {T} = Elemental_elt_vec{T}(Vector{T}(get_vec(eev1) .+ get_vec(eev2)), Vector{Int}(get_indices(eev1)), get_nie(eev1))
 (*)(eev::Elemental_elt_vec{T}, val::Y) where {T, Y} = Elemental_elt_vec{T}(Vector{T}(val .* get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
 (*)(val::Y, eev::Elemental_elt_vec{T}) where {T, Y} = Elemental_elt_vec{T}(Vector{T}(val .* get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))
 (*)(eev::Elemental_elt_vec{T}, val::Y) where {T, Y} = Elemental_elt_vec{T}(Vector{T}(val .* get_vec(eev)), Vector{Int}(get_indices(eev)), get_nie(eev))

--- a/src/P_vec/elemental_pv.jl
+++ b/src/P_vec/elemental_pv.jl
@@ -149,14 +149,14 @@ minus_epv!(epv::Elemental_pv{T}) where {T <: Number} =
 function (-)(epv::Elemental_pv) 
   _epv = copy(epv)
   minus_epv!(_epv)
-  set_v!(_epv, - get_v(epv))
+  # set_v!(_epv, - get_v(epv))
   return _epv
 end
 
 function (-)(epv1::Elemental_pv, epv2::Elemental_pv)
   _epv = - epv2
   add_epv!(epv1, _epv)
-  set_v!(_epv, get_v(epv1) - get_v(epv2))
+  # set_v!(_epv, get_v(epv1) - get_v(epv2))
   return _epv
 end
 
@@ -178,18 +178,20 @@ end
 function (+)(epv1::Elemental_pv{T}, epv2::Elemental_pv{T}) where T
   _epv = copy(epv1)::Elemental_pv{T}
   add_epv!(epv2, _epv)
-  set_v!(_epv, get_v(epv1) + get_v(epv2))
+  # set_v!(_epv, get_v(epv1) + get_v(epv2))
   return _epv
 end
+
+
+(*)(val::Y, epv::Elemental_pv{T}) where {T,Y} = (*)(epv, val)
 
 function (*)(epv::Elemental_pv{T}, val::Y) where {T,Y}
   _epv = copy(epv)::Elemental_pv{T}
   N = get_N(_epv)
   for i = 1:N
-    # get_eev_set(_epv, i) = get_eev_set(_epv, i) * val
     get_eev_value(_epv, i) .= get_eev_value(_epv, i) .* val
   end
-  get_v(_epv) .*= val  
+  # get_v(_epv) .*= val  
   return _epv
 end
 

--- a/src/P_vec/elemental_pv.jl
+++ b/src/P_vec/elemental_pv.jl
@@ -95,20 +95,6 @@ Set either the `i`-th elemental element-vector `epv` to `vec` or its `j`-th comp
 @inline copy(epv::Elemental_pv{T}) where {T} =
   Elemental_pv{T}(get_N(epv), get_n(epv), copy.(get_eev_set(epv)), Vector{T}(get_v(epv)))
 
-# function broadcast!(f::Function, epv::Elemental_pv{T}, As...) where {T}  
-#   map(element -> broadcast!(f, element, As...), epv.eev_set)
-#   broadcast!(f, get_v(epv), As...)
-#   return epv
-# end
-
-# function broadcast!(f::Function, epv_res::Elemental_pv{T}, epv::Elemental_pv{T}, As...) where {T}  
-#   epv_from_epv!(epv_res, epv)
-#   map(element -> broadcast!(f, element, As...), epv_res.eev_set)
-#   get_v(epv_res) .= get_v(epv)
-#   broadcast!(f, get_v(epv), As...)
-#   return epv_res
-# end
-
 function setindex!(epv::Elemental_pv, vec, inds...)
   setindex!(get_v(epv), vec, inds...)
   epv_from_v!(epv, get_v(epv)) # get_v(epv) == vec
@@ -148,15 +134,13 @@ minus_epv!(epv::Elemental_pv{T}) where {T <: Number} =
 
 function (-)(epv::Elemental_pv) 
   _epv = copy(epv)
-  minus_epv!(_epv)
-  # set_v!(_epv, - get_v(epv))
+  minus_epv!(_epv)  
   return _epv
 end
 
 function (-)(epv1::Elemental_pv, epv2::Elemental_pv)
   _epv = - epv2
   add_epv!(epv1, _epv)
-  # set_v!(_epv, get_v(epv1) - get_v(epv2))
   return _epv
 end
 
@@ -210,7 +194,7 @@ Create an elemental partitioned-vector from a vector `eev_set` of: `SparseVector
 ) = create_epv(vec_elt_var, n; type)
 
 function create_epv(eev_set::Vector{Elemental_elt_vec{T}}; n = max_indices(eev_set)) where {T<:Number}
-  N = length(eev_set)
+  N = (n != 0) ? length(eev_set) : 0
   v = zeros(T, n)
   return Elemental_pv{T}(N, n, eev_set, v)
 end

--- a/src/P_vec/elt_vec.jl
+++ b/src/P_vec/elt_vec.jl
@@ -4,7 +4,7 @@ using ..Acronyms
 using ..M_abstract_element_struct
 
 export Elt_vec
-export get_vec, set_vec!
+export get_vec, get_vec_from_indices, set_vec!
 export set_add_vec!, set_minus_vec!
 
 """Supertype of element-vectors."""
@@ -18,6 +18,8 @@ Return the vector `ev.vec` or `ev.vec[i]` from an element-vector.
 """
 @inline get_vec(ev::T) where {T <: Elt_vec} = ev.vec
 @inline get_vec(ev::T, i::Int) where {T <: Elt_vec} = ev.vec[i]
+
+@inline get_vec_from_indices(ev::T, i::Int) where {T <: Elt_vec} = get_vec(ev, findfirst(x -> x==i, get_indices(ev)))
 
 """
     set_vec!(ev::T, vec::Vector{Y}) where {Y <: Number, T <: Elt_vec{Y}}

--- a/src/PartitionedStructures.jl
+++ b/src/PartitionedStructures.jl
@@ -21,7 +21,7 @@ include("P_mat/_include.jl")
 include("methods/_include.jl")
 
 
-include("partitioned_vectors.jl")
+# include("partitioned_vectors.jl")
 
 
 # use the submodule of PartitionedStructures.jl
@@ -35,8 +35,8 @@ using .ModElemental_pv,
 using .PartitionedQuasiNewton, .PartitionedLOQuasiNewton
 using .Link, .Instances, .PartMatInterface
 
-using ..PartitionedVectors
-export PartitionedVector, build!
+# using ..PartitionedVectors
+# export PartitionedVector, build!
 # export the main methods of every submodule
 
 # structures and functions related to element-structures

--- a/src/partitioned_vectors.jl
+++ b/src/partitioned_vectors.jl
@@ -9,13 +9,15 @@ import Base: +, -, ==, *
 import Base: copy, similar
 import Base: show, size, length, getindex, setindex!, firstindex, lastindex
 
-import LinearAlgebra: norm, dot, axpy!
+import LinearAlgebra: norm, dot, axpy!, axpby!
 
 export PartitionedVector
 export build!
 
+abstract type AbstractPartitionedVector{T} <: DenseVector{T} end # for Krylov 
+
 # mutable struct PartitionedVector{T} <: AbstractVector{T}
-mutable struct PartitionedVector{T} <: DenseVector{T} # for Krylov
+mutable struct PartitionedVector{T} <: AbstractPartitionedVector{T}
   epv::Elemental_pv{T}
   vec::Vector{T}
   simulate_vector::Bool
@@ -46,44 +48,16 @@ function show(io::IO, pv::PartitionedVector)
   return nothing
 end
 
-# function broadcast!(f::Function, pv::PartitionedVector, As...)
-#   broadcast!(f, pv.epv, As...)
-#   return pv
-# end
-
-# function broadcast!(f::Function, pv1::PartitionedVector, pv2::PartitionedVector, As...)
-#   epv1 = pv1.epv
-#   epv2 = pv2.epv
-#   broadcast!(f, epv1, epv2, As...)
-#   return pv
-# end
-
-# function copyto!(dest::Elemental_elt_vec, do, src, so, N)
-
-# function setindex!(vec::AbstractVector, pv::PartitionedVector, inds...)
-#   setindex!(vec, pv.epv, inds...)  
-#   return vec
-# end
-
-# function Base.materialize!(pvdest::PartitionedVector, pvsrc::PartitionedVector)
-#   epv_from_epv!(pvdest.epv, pvsrc.epv)
-#   pvdest.vec .= pvsrc.vec
-#   return pvdest
-# end 
-
 getindex(pv::PartitionedVector, inds...) = get_eev_set(pv.epv)[inds...]
 
 function setindex!(pv::PartitionedVector, eev::Elemental_elt_vec, index::Int)
+  # println("setindex")
+  # println(eev)
   get_eev_value(pv.epv, index) .= get_vec(eev)
   return pv
 end 
 
-# function setindex!(eev1::Elemental_elt_vec, eev2::Elemental_elt_vec, inds...)
-#   get_vec(eev1)[inds...] .= get_vec(eev2)[inds...]
-#   return pv
-# end
-
-function setindex!(pv::PartitionedVector{T}, val::T, index::Int) where T
+function setindex!(pv::PartitionedVector{T}, val::T, index::Int) where T<:Number
   get_eev_value(pv.epv, index) .= val
   get_v(pv.epv) .= val
   return pv
@@ -91,48 +65,6 @@ end
 
 firstindex(pv::PartitionedVector) = get_N(pv.epv) > 0 ? 1 : 0
 lastindex(pv::PartitionedVector) = get_N(pv.epv)
-
-function Broadcast.broadcasted(::typeof(identity), pv1::PartitionedVector, pv2::PartitionedVector)
-  epv_from_epv!(pv1.epv, pv2.epv)
-  return pv1
-end
-
-function Broadcast.broadcasted(::typeof(+), pv1::PartitionedVector, pv2::PartitionedVector)
-  epv1 = pv1.epv
-  epv2 = pv2.epv
-  _epv = (+)(epv1, epv2)
-  return PartitionedVector(_epv)
-end
-
-function Broadcast.broadcasted(::typeof(.+), pv1::PartitionedVector, pv2::PartitionedVector)
-  println("test")
-  epv1 = pv1.epv
-  epv2 = pv2.epv
-  _epv = (+)(epv1, epv2)
-  return PartitionedVector(_epv)
-end
-
-function Broadcast.broadcasted(::typeof(-), pv::PartitionedVector)
-  epv = pv.epv  
-  _epv = (-)(epv)
-  return PartitionedVector(_epv)
-end
-
-function Broadcast.broadcasted(::typeof(-), pv1::PartitionedVector, pv2::PartitionedVector)
-  epv1 = pv1.epv
-  epv2 = pv2.epv
-  _epv = (-)(epv1, epv2)
-  return PartitionedVector(_epv)
-end
-
-function Broadcast.broadcasted(::typeof(*), pv::PartitionedVector, val::Y) where Y
-  println("test *")
-  epv = pv.epv
-  _epv = (*)(epv, val)
-  return PartitionedVector(_epv)
-end
-
-Broadcast.broadcasted(::typeof(*), val::Y, pv::PartitionedVector) where Y = Broadcast.broadcasted(*, pv, val)
 
 function (+)(pv1::PartitionedVector, pv2::PartitionedVector)
   epv1 = pv1.epv
@@ -172,23 +104,116 @@ copy(pv::PartitionedVector{T}; simulate_vector::Bool=pv.simulate_vector) where {
 similar(pv::PartitionedVector{T}; simulate_vector::Bool=pv.simulate_vector) where {T <: Number} = PartitionedVector{T}(similar(pv.epv), similar(pv.vec), simulate_vector)
 similar(pv::PartitionedVector{T}, ::Type{T}, n::Int; simulate_vector::Bool=pv.simulate_vector) where {T <: Number} = PartitionedVector{T}(similar(pv.epv), similar(pv.vec), simulate_vector)
 
-build!(pv::PartitionedVector) = build_v!(pv.epv)
+build!(pv::PartitionedVector) = build!(pv, Val(pv.simulate_vector))
+
+function build!(pv::PartitionedVector, ::Val{true}) 
+  epv = pv.epv
+  vec = epv.v
+  component_list = epv.component_list
+  for i in 1:length(vec)
+    index_element = component_list[i][1]
+    eev = get_eev_set(epv, index_element)
+    val = get_vec_from_indices(eev, i)
+    vec[i] = val
+  end
+  return pv
+end
+
+build!(pv::PartitionedVector, ::Val{false}) = build_v!(pv.epv)
 
 function norm(pv::PartitionedVector, p::Real=2)
-  pv.vec .= get_v(pv.epv)
   build!(pv)
   _norm = norm(get_v(pv.epv), p)
-  get_v(pv.epv).= pv.vec
   return _norm
 end
 
 function dot(pv1::PartitionedVector{T}, pv2::PartitionedVector{T}) where T
+  build!(pv1)
+  build!(pv2)
   dot(get_v(pv1.epv), get_v(pv2.epv))
 end
 
 function axpy!(s::Y, x::PartitionedVector{T}, y::PartitionedVector{T}) where {T<:Number,Y<:Number}
+  axpy!(s,x,y,Val(x.simulate_vector), Val(y.simulate_vector))
+end
+
+function axpy!(s::Y, x::PartitionedVector{T}, y::PartitionedVector{T}, ::Val{true}, ::Val{false}) where {T<:Number,Y<:Number}
+  build!(x)
+  build!(y)
+  xvector = x.epv.v
+  yvector = y.epv.v
+  epv_from_v!(y.epv, s .* xvector .+ yvector)
+  return y
+end
+
+function axpy!(s::Y, x::PartitionedVector{T}, y::PartitionedVector{T}, ::Val{true}, ::Val{true}) where {T<:Number,Y<:Number}
   y .+= s .* x
   return y
+end
+
+function axpy!(s::Y, x::PartitionedVector{T}, y::PartitionedVector{T}, ::Val{false}, ::Val{true}) where {T<:Number,Y<:Number}
+  build!(x)
+  build!(y)
+  xvector = x.epv.v
+  yvector = y.epv.v
+  epv_from_v!(y.epv, s .* xvector .+ yvector)
+  return y
+  y .+= s .* x
+  return y
+end
+
+function axpby!(s::Y1, x::PartitionedVector{T}, t::Y2, y::PartitionedVector{T}) where {T<:Number,Y1<:Number,Y2<:Number}
+  axpby!(s, x, t, y, Val(x.simulate_vector), Val(y.simulate_vector))
+end
+
+function axpby!(s::Y1, x::PartitionedVector{T}, t::Y2, y::PartitionedVector{T}, ::Val{false}, ::Val{true}) where {T<:Number,Y1<:Number,Y2<:Number}
+  build!(x)
+  build!(y)
+  xvector = x.epv.v
+  yvector = y.epv.v
+  epv_from_v!(y.epv, s .* xvector .+ yvector .* t)
+end
+
+function axpby!(s::Y1, x::PartitionedVector{T}, t::Y2, y::PartitionedVector{T}, ::Val{true}, ::Val{true}) where {T<:Number,Y1<:Number,Y2<:Number}
+  y .= x .* s .+ y .* t
+end
+
+
+Base.broadcastable(pv::PartitionedVector) = pv
+
+struct PartitionedVectorStyle <: Base.Broadcast.BroadcastStyle end
+
+Base.BroadcastStyle(::Type{PartitionedVector{T}}) where T = PartitionedVectorStyle()
+
+Base.BroadcastStyle(::PartitionedVectorStyle, ::PartitionedVectorStyle) = PartitionedVectorStyle()
+Base.BroadcastStyle(::PartitionedVectorStyle, ::Base.Broadcast.BroadcastStyle) = PartitionedVectorStyle()
+Base.BroadcastStyle(::Base.Broadcast.BroadcastStyle, ::PartitionedVectorStyle) = PartitionedVectorStyle()
+
+function Base.similar(bc::Base.Broadcast.Broadcasted{PartitionedVectorStyle}, ::Type{ElType}) where ElType
+  # println("similar")
+  pv = find_pv(bc)
+  pvres = similar(pv)
+  return pvres
+end
+
+function Base.copy(bc::Base.Broadcast.Broadcasted{PartitionedVectorStyle})
+  # println("copy")
+  pv = find_pv(bc)
+  pvres = copy(pv)
+  return pvres
+end
+
+find_pv(bc::Base.Broadcast.Broadcasted) = find_pv(bc.args)
+find_pv(args::Tuple) = find_pv(find_pv(args[1]), Base.tail(args))
+find_pv(x) = x
+find_pv(::Tuple{}) = nothing
+find_pv(a::PartitionedVector, rest) = a
+find_pv(::Any, rest) = find_pv(rest)
+
+function Base.Vector(pv::PartitionedVector{T}) where T
+  build!(pv)
+  vector = pv.epv.v  
+  return Vector{T}(copy(vector))
 end
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,7 @@ my_and = (a::Bool, b::Bool) -> (a && b)
 Return the maximum index of the element variables in `list_of_element_variables` or in `elt_set`.
 """
 max_indices(elt_vars::Vector{Vector{T}}) where {T <: Number} =
-  isempty(elt_vars) ? 0 : maximum(maximum.(elt_vars))
+  isempty(elt_vars[1]) ? 0 : maximum(maximum.(elt_vars))
 
 """
     indice_min = min_indices(list_of_element_variables::Vector{Vector{T}}) where T
@@ -28,7 +28,7 @@ max_indices(elt_vars::Vector{Vector{T}}) where {T <: Number} =
 Return the minimum index of the element variables in `list_of_element_variables` or in `elt_set`.
 """
 min_indices(elt_vars::Vector{Vector{T}}) where {T <: Number} =
-  isempty(elt_vars) ? 0 : minimum(minimum.(elt_vars))
+  isempty(elt_vars[1]) ? 0 : minimum(minimum.(elt_vars))
 
 """
     BFGS(s::Vector{Y}, y::Vector{Y}, B::Array{Y,2}; kwargs...) where Y <: Number

--- a/test/P_vec/ev.jl
+++ b/test/P_vec/ev.jl
@@ -6,7 +6,6 @@ using PartitionedStructures.M_abstract_element_struct
 
 @testset "Test ev getter/setter" begin
   nᵢᴱ = 5
-  nᵢᴵ = 2
 
   # elemental
   ev1 = new_eev(nᵢᴱ)
@@ -65,4 +64,12 @@ end
   [lin_com[i, i] = 1 for i = 1:nᵢᴱ]
   sv = sparsevec(i1, v1)
   _tmp = rand(Int, nᵢᴱ)
+end
+
+@testset "Base.methods" begin
+  eev = Elemental_elt_vec([1:3;], [1:2:5;], 3)
+
+  @test 2 * eev == eev + eev
+  @test - eev == -1 * eev
+  @test eev - eev == 0 * eev
 end

--- a/test/P_vec/pv.jl
+++ b/test/P_vec/pv.jl
@@ -179,3 +179,17 @@ end
   a = @allocated add_epv!(epv, epv2)
   @test a == 0
 end
+
+@testset "Base.methods" begin
+  N = 15
+  n = 30
+  ni = 5
+  element_variables = map(i -> sample(1:n, ni, replace = false), 1:N)
+
+  epv = create_epv(element_variables)
+
+  @test epv + epv == 2 * epv
+  @test - epv == -1 * epv
+  @test epv - epv == 0 * epv
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,4 @@ include("P_mat/_include.jl")
 include("others/_include.jl")
 include("ab_ps_struct.jl")
 
-include("partitionedvectors.jl")
+# include("partitionedvectors.jl")


### PR DESCRIPTION
@dpo (@amontoison) here is the PR defining `PartitionedVector`s which can be transmit to `Krylov.cg!` paired with a partitioned `LinearOperator`.
The code of the PR (related to `PartitionedVector`) is not enough, so the following piece of code (which is not part of the PR) define: a partitioned `LinearOperator`, a `CgSolver`'s constructor dedicated to `PartitionedVector`s and an example.

Note that we will have to make `solver.warm_start =true` in the `<:AbstractPartiallySeparableNLPModel` callback to avoid
https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/66e1fd140f1963089cc7e0a5a0e11cef9b41c6ab/src/cg.jl#L116
in `cg!`,  which produces an error.

Next week, I will make a module PartitionedVectors.jl based on PartitionedStructures.jl.
This way, I will not add Krylov.jl and (later) JSOSolver.jl in the dependencies of PartitionedStructures.jl.

```julia
using StatsBase, LinearAlgebra

using LinearOperators, Krylov

using PartitionedStructures

N = 15
n = 20
nie = 5
element_variables =
  vcat(map((i -> sample(1:n, nie, replace = false)), 1:(N -4)), [[1:5;], [6:10;], [11:15;], [16:20;]])

function partitionedMulOp!(epm, pv_res::PartitionedVector, pv::PartitionedVector, α, β)
  epv = pv.epv
  epv_res = pv_res.epv
  mul_epm_epv!(epv_res, epm, epv)
  pv_res.vec .= PartitionedStructures.get_v(epv_res)
  build_v!(epv_res)
  mul!(pv_res.vec, I, PartitionedStructures.get_v(epv_res), α, β)
  return pv_res
end

using PartitionedStructures.M_part_mat
function LinearOperators.LinearOperator(epm::Part_mat{T}) where T
  n = get_n(epm)
  B = LinearOperator(T, n, n, true, true, (pv_res, pv, α, β) -> partitionedMulOp!(epm, pv_res, pv, α, β))
  return B
end

function LinearAlgebra.mul!(res::PartitionedVector, op::AbstractLinearOperator{T}, v::PartitionedVector, α, β) where {T}
  op.prod!(res, v, α, β)
end

function Krylov.CgSolver(pv::PartitionedVector{T}) where T  
  Δx = similar(pv; simulate_vector=true)
  Δx .= (T)(0)
  x  = similar(pv; simulate_vector=true)
  x .= (T)(0)
  r  = similar(pv; simulate_vector=true)
  r .= (T)(0)
  p  = similar(pv; simulate_vector=true)
  p .= (T)(0)
  Ap = similar(pv; simulate_vector=false)
  Ap .= (T)(0)
  z = similar(pv; simulate_vector=true)
  z .= (T)(0)
  stats = Krylov.SimpleStats(0, false, false, T[], T[], T[], "unknown")
  solver = Krylov.CgSolver{T,T,PartitionedVector{T}}(Δx, x, r, p, Ap, z, true, stats)
  return solver
end

pv_gradient = PartitionedVector(element_variables; T=Float32)

epm = epm_from_epv(pv_gradient 
update!(epm, pv_gradient, Float32(2.) * pv_gradient) # more interesting than overlapping identities

lo_epm = LinearOperators.LinearOperator(epm)
solver = CgSolver(pv_gradient)

pv_gradient .= 10 .* pv_gradient

cg!(solver, lo_epm, -pv_gradient; verbose=1)

x = Vector(solution(solver))
g = Vector(pv_gradient)
A = Matrix(epm)

norm(A*x + g)
```