### PR TITLE
Support partitioned matrices with linear contribution

### DIFF
--- a/src/P_mat/elemental_elo_BFGS.jl
+++ b/src/P_mat/elemental_elo_BFGS.jl
@@ -13,11 +13,12 @@ export reset_eelo_bfgs!
 """
     Elemental_elo_bfgs{T} <: LOEltMat{T}
 
-Represent an elemental element `LBFGSOperator`.
-`indices` retains the indices of the elemental variables.
-`nie` is the elemental size (`=length(indices)`).
-`Bie` a `LBFGSOperator`.
-`counter` counts how many update the elemental limited-memory operator goes through from its allocation.
+Represent an elemental element `LBFGSOperator`:
+* `indices` retains the indices of the elemental variables;
+* `nie` is the elemental size (`=length(indices)`);
+* `Bie` a `LBFGSOperator`;
+* `linear`: if `linear==true`, then the element matrix contribution is null;
+* `counter` counts how many update the elemental limited-memory operator goes through from its allocation.
 """
 mutable struct Elemental_elo_bfgs{T} <: LOEltMat{T}
   nie::Int # nᵢᴱ

--- a/src/P_mat/elemental_elo_SR1.jl
+++ b/src/P_mat/elemental_elo_SR1.jl
@@ -13,11 +13,12 @@ export reset_eelo_sr1!
 """
     Elemental_elo_sr1{T} <: LOEltMat{T}
 
-Represent an elemental element `LSR1Operator`.
-`indices` retains the indices of the elemental variables.
-`nie` is the elemental size (`=length(indices)`).
-`Bie` a `LSR1Operator`.
-`counter` counts how many update the elemental limited-memory operator goes through from its allocation.
+Represent an elemental element `LSR1Operator`;
+* `indices` retains the indices of the elemental variables;
+* `nie` is the elemental size (`=length(indices)`);
+* `Bie` a `LSR1Operator`;
+* `linear`: if `linear==true`, then the element matrix contribution is null;
+* `counter` counts how many update the elemental limited-memory operator goes through from its allocation.
 """
 mutable struct Elemental_elo_sr1{T} <: LOEltMat{T}
   nie::Int # nᵢᴱ

--- a/src/P_mat/elemental_elo_SR1.jl
+++ b/src/P_mat/elemental_elo_SR1.jl
@@ -24,11 +24,13 @@ mutable struct Elemental_elo_sr1{T} <: LOEltMat{T}
   indices::Vector{Int} # size nᵢᴱ
   Bie::LinearOperators.LSR1Operator{T}
   counter::Counter_elt_mat
+  linear::Bool
 end
 
 @inline (==)(eelo1::Elemental_elo_sr1{T}, eelo2::Elemental_elo_sr1{T}) where {T} =
   (get_nie(eelo1) == get_nie(eelo2)) &&
   (get_indices(eelo1) == get_indices(eelo2)) &&
+  (get_linear(eelo1) == get_linear(eelo2)) &&
   begin
     v = rand(get_nie(eelo1))
     (get_Bie(eelo1) * v == get_Bie(eelo2) * v)
@@ -38,12 +40,14 @@ end
   copy(get_indices(eelo)),
   deepcopy(get_Bie(eelo)),
   copy(get_cem(eelo)),
+  copy(get_linear(eelo)),
 )
 @inline similar(eelo::Elemental_elo_sr1{T}) where {T} = Elemental_elo_sr1{T}(
   copy(get_nie(eelo)),
   copy(get_indices(eelo)),
   LSR1Operator(T, get_nie(eelo)),
   copy(get_cem(eelo)),
+  copy(get_linear(eelo)),
 )
 
 """
@@ -51,11 +55,12 @@ end
 
 Return an `Elemental_elo_sr1` of type `T` based on the vector of the elemental variables `elt_var`.
 """
-function init_eelo_LSR1(elt_var::Vector{Int}; T = Float64)
+function init_eelo_LSR1(elt_var::Vector{Int}; T = Float64, linear=false)
   nie = length(elt_var)
-  Bie = LinearOperators.LSR1Operator(T, nie)
+  _nie = (!linear) * nie
+  Bie = LinearOperators.LSR1Operator(T, _nie)
   counter = Counter_elt_mat()
-  eelo = Elemental_elo_sr1{T}(nie, elt_var, Bie, counter)
+  eelo = Elemental_elo_sr1{T}(nie, elt_var, Bie, counter, linear)
   return eelo
 end
 
@@ -64,11 +69,12 @@ end
 
 Return an `Elemental_elo_sr1` of type `T` with `nie` random indices within the range `1:n`.
 """
-function LSR1_eelo_rand(nie::Int; T = Float64, n = nie^2)
+function LSR1_eelo_rand(nie::Int; T = Float64, n = nie^2, linear=false)
   indices = rand(1:n, nie)
-  Bie = LinearOperators.LSR1Operator(T, nie)
+  _nie = (!linear) * nie
+  Bie = LinearOperators.LSR1Operator(T, _nie)
   counter = Counter_elt_mat()
-  eelo = Elemental_elo_sr1{T}(nie, indices, Bie, counter)
+  eelo = Elemental_elo_sr1{T}(nie, indices, Bie, counter, linear)
   return eelo
 end
 
@@ -77,11 +83,12 @@ end
 
 Return an `Elemental_elo_sr1` of type `T` of size `nie`, the indices are all the values in the range `index:index+nie-1`.
 """
-function LSR1_eelo(nie::Int; T = Float64, index = 1)
+function LSR1_eelo(nie::Int; T = Float64, index = 1, linear=false)
   indices = [index:1:(index + nie - 1);]
-  Bie = LinearOperators.LSR1Operator(T, nie)
+  _nie = (!linear) * nie
+  Bie = LinearOperators.LSR1Operator(T, _nie)
   counter = Counter_elt_mat()
-  eelo = Elemental_elo_sr1{T}(nie, indices, Bie, counter)
+  eelo = Elemental_elo_sr1{T}(nie, indices, Bie, counter, linear)
   return eelo
 end
 

--- a/src/P_mat/elemental_em.jl
+++ b/src/P_mat/elemental_em.jl
@@ -19,7 +19,8 @@ It has fields:
 * `nie`: elemental size (`=length(indices)`);
 * `Bie::Symmetric{T, Matrix{T}}`: the elemental matrix;
 * `counter`: counts how many update the elemental matrix goes through from its allocation;
-* `convex`: if `Elemental_em` is by default update with BFGS or SR1;
+* `convex`: if `convex==true`, then `Elemental_em` default update is BFGS otherwise it is SR1;
+* `linear`: if `linear==true`, then the element matrix contribution is null;
 * `_Bsr`: a vector used during quasi-Newton update of the elemental matrix.
 """
 mutable struct Elemental_em{T} <: DenseEltMat{T}

--- a/src/P_mat/elemental_plo.jl
+++ b/src/P_mat/elemental_plo.jl
@@ -81,10 +81,14 @@ identity_eplo_LOSE(
   N::Int = length(element_variables),
   n::Int = max_indices(element_variables),
   T = Float64,
-) = identity_eplo_LOSE(element_variables, N, n; T)
+  linear_vector::Vector{Bool} = zeros(Bool, N),
+) = identity_eplo_LOSE(element_variables, N, n; T, linear_vector)
 
-function identity_eplo_LOSE(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64)
-  eelo_set = map((elt_var -> init_eelo_LBFGS(elt_var; T = T)), element_variables)
+function identity_eplo_LOSE(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64, linear_vector::Vector{Bool} = zeros(Bool, N),)  
+  eelo_set = map(
+    (i -> init_eelo_LBFGS(element_variables[i]; T, linear = linear_vector[i])),
+    1:length(element_variables),
+  )
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
   component_list = map(i -> Vector{Int}(undef, 0), [1:n;])

--- a/src/P_mat/elemental_plo.jl
+++ b/src/P_mat/elemental_plo.jl
@@ -70,11 +70,12 @@ end
 )
 
 """
-    eplo = identity_eplo_LOSE(element_variables::Vector{Vector{Int}}; N::Int=length(element_variables), n::Int=max_indices(element_variables), T=Float64)
-    eplo = identity_eplo_LOSE(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T=Float64)
+    eplo = identity_eplo_LOSE(element_variables::Vector{Vector{Int}}; N::Int=length(element_variables), n::Int=max_indices(element_variables), T=Float64, linear_vector::Vector{Bool} = zeros(Bool, N))
+    eplo = identity_eplo_LOSE(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T=Float64, linear_vector::Vector{Bool} = zeros(Bool, N))
 
 Create an elemental partitionned limited-memory operator of `N` elemental element linear-operators initialized with LBFGS operators.
 The positions are given by the vector of the element variables `element_variables`.
+`linear_vector` indicates which element linear-opeartor should not contribute to the partitioned linear-operator.
 """
 identity_eplo_LOSE(
   element_variables::Vector{Vector{Int}};

--- a/src/P_mat/elemental_plo_BFGS.jl
+++ b/src/P_mat/elemental_plo_BFGS.jl
@@ -62,11 +62,12 @@ end
 )
 
 """
-    eplo = identity_eplo_LBFGS(element_variables::Vector{Vector{Int}}; N::Int=length(element_variables), n::Int=max_indices(element_variables), T=Float64)
-    eplo = identity_eplo_LBFGS(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T=Float64)
+    eplo = identity_eplo_LBFGS(element_variables::Vector{Vector{Int}}; N::Int=length(element_variables), n::Int=max_indices(element_variables), T=Float64, linear_vector::Vector{Bool} = zeros(Bool, N))
+    eplo = identity_eplo_LBFGS(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T=Float64, linear_vector::Vector{Bool} = zeros(Bool, N))
 
 Return an $(_eplmo) PLBFGS of `N` elemental element linear-operators.
 The positions are given by the vector of the element variables `element_variables`.
+`linear_vector` indicates which element linear-opeartor should not contribute to the partitioned linear-operator.
 """
 identity_eplo_LBFGS(
   element_variables::Vector{Vector{Int}};

--- a/src/P_mat/elemental_plo_BFGS.jl
+++ b/src/P_mat/elemental_plo_BFGS.jl
@@ -73,10 +73,14 @@ identity_eplo_LBFGS(
   N::Int = length(element_variables),
   n::Int = max_indices(element_variables),
   T = Float64,
-) = identity_eplo_LBFGS(element_variables, N, n; T)
+  linear_vector::Vector{Bool} = zeros(Bool, N),
+) = identity_eplo_LBFGS(element_variables, N, n; T, linear_vector)
 
-function identity_eplo_LBFGS(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64)
-  eelo_set = map((elt_var -> init_eelo_LBFGS(elt_var; T = T)), element_variables)
+function identity_eplo_LBFGS(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64, linear_vector::Vector{Bool} = zeros(Bool, N),)  
+  eelo_set = map(
+    (i -> init_eelo_LBFGS(element_variables[i]; T, linear = linear_vector[i])),
+    1:length(element_variables),
+  )
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
   component_list = map(i -> Vector{Int}(undef, 0), [1:n;])

--- a/src/P_mat/elemental_plo_SR1.jl
+++ b/src/P_mat/elemental_plo_SR1.jl
@@ -74,11 +74,15 @@ identity_eplo_LSR1(
   N::Int = length(element_variables),
   n::Int = max_indices(element_variables),
   T = Float64,
-) = identity_eplo_LSR1(element_variables, N, n; T = Float64)
+  linear_vector::Vector{Bool} = zeros(Bool, N),
+) = identity_eplo_LSR1(element_variables, N, n; T, linear_vector)
 
-function identity_eplo_LSR1(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64)
-  length(element_variables) != N && @error("unvalid list of element indices, PLSR1")
-  eelo_set = map((elt_var -> init_eelo_LSR1(elt_var; T = T)), element_variables)
+function identity_eplo_LSR1(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T = Float64, linear_vector::Vector{Bool} = zeros(Bool, N),)
+  length(element_variables) != N && @error("unvalid list of element indices, PLSR1")  
+  eelo_set = map(
+    (i -> init_eelo_LSR1(element_variables[i]; T, linear = linear_vector[i])),
+    1:length(element_variables),
+  )
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
   component_list = map(i -> Vector{Int}(undef, 0), [1:n;])

--- a/src/P_mat/elemental_plo_SR1.jl
+++ b/src/P_mat/elemental_plo_SR1.jl
@@ -63,11 +63,12 @@ end
 )
 
 """
-    eplo = identity_eplo_LSR1(element_variables::Vector{Vector{Int}}; N::Int=length(element_variables), n::Int=max_indices(element_variables), T=Float64)
-    eplo = identity_eplo_LSR1(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T=Float64)
+    eplo = identity_eplo_LSR1(element_variables::Vector{Vector{Int}}; N::Int=length(element_variables), n::Int=max_indices(element_variables), T=Float64, linear_vector::Vector{Bool} = zeros(Bool, N))
+    eplo = identity_eplo_LSR1(element_variables::Vector{Vector{Int}}, N::Int, n::Int; T=Float64, linear_vector::Vector{Bool} = zeros(Bool, N))
 
 Return an elemental partitionned limited-memory operator PLSR1 of `N` elemental element linear-operators.
 The positions are given by the vector of the element variables `element_variables`.
+`linear_vector` indicates which element linear-opeartor should not contribute to the partitioned linear-operator.
 """
 identity_eplo_LSR1(
   element_variables::Vector{Vector{Int}};

--- a/src/P_mat/elemental_pm.jl
+++ b/src/P_mat/elemental_pm.jl
@@ -120,7 +120,8 @@ identity_epm(
   n::Int = max_indices(element_variables),
   T = Float64,
   convex_vector::Vector{Bool} = zeros(Bool, N),
-) = identity_epm(element_variables, N, n; T, convex_vector)
+  linear_vector::Vector{Bool} = zeros(Bool, N),
+) = identity_epm(element_variables, N, n; T, convex_vector, linear_vector)
 
 function identity_epm(
   element_variables::Vector{Vector{Int}},
@@ -128,9 +129,10 @@ function identity_epm(
   n::Int;
   T = Float64,
   convex_vector::Vector{Bool} = zeros(Bool, N),
+  linear_vector::Vector{Bool} = zeros(Bool, N),
 )
   eem_set = map(
-    (i -> create_id_eem(element_variables[i]; T = T, bool = convex_vector[i])),
+    (i -> create_id_eem(element_variables[i]; T = T, convex = convex_vector[i], linear = linear_vector[i])),
     1:length(element_variables),
   )
   spm = spzeros(T, n, n)
@@ -154,8 +156,9 @@ function identity_epm(
   T = Float64,
   nie::Int = 5,
   convex_vector::Vector{Bool} = zeros(Bool, N),
+  linear_vector::Vector{Bool} = zeros(Bool, N),
 )
-  eem_set = map(i -> identity_eem(nie; T = T, n = n, bool = convex_vector[i]), [1:N;])
+  eem_set = map(i -> identity_eem(nie; T = T, n = n, convex = convex_vector[i], linear = linear_vector[i]), [1:N;])
   spm = spzeros(T, n, n)
   L = spzeros(T, n, n)
   component_list = map(i -> Vector{Int}(undef, 0), [1:n;])

--- a/src/P_mat/elt_mat.jl
+++ b/src/P_mat/elt_mat.jl
@@ -5,7 +5,7 @@ using ..M_abstract_element_struct
 
 export Elt_mat, DenseEltMat, LOEltMat
 export get_Bie, get_Bsr
-export get_counter_elt_mat, get_cem, get_current_untouched, get_index, get_convex
+export get_counter_elt_mat, get_cem, get_current_untouched, get_index, get_convex, get_linear
 
 export Counter_elt_mat
 export update_counter_elt_mat!, iter_info, total_info
@@ -71,6 +71,8 @@ If the last partitioned-update updates `elt_mat` then `index` will be equal to `
 @inline get_index(elt_mat::T) where {T <: Elt_mat} = get_current_untouched(elt_mat.counter)
 
 @inline get_convex(elt_mat::Elt_mat) = elt_mat.convex
+
+@inline get_linear(elt_mat::Elt_mat) = elt_mat.linear
 
 Counter_elt_mat() = Counter_elt_mat(0, 0, 0, 0, 0, 0)
 copy(cem::Counter_elt_mat) = Counter_elt_mat(

--- a/src/P_mat/part_mat.jl
+++ b/src/P_mat/part_mat.jl
@@ -38,13 +38,16 @@ function set_spm!(plm::P) where {T <: Number, P <: Part_LO_mat{T}}
   n = get_n(plm)
   spm = get_spm(plm)
   for i = 1:N
-    plmᵢ = get_eelo_set(plm, i)
-    nie = get_nie(plmᵢ)
-    Bie = get_Bie(plmᵢ)
-    indicesᵢ = get_indices(plmᵢ)
-    value_Bie = zeros(T, nie, nie)
-    map((i -> value_Bie[:, i] .= Bie * SparseVector(nie, [i], [1])), 1:nie)
-    spm[indicesᵢ, indicesᵢ] .+= value_Bie
+    elmᵢ = get_eelo_set(plm, i)    
+    linear = get_linear(elmᵢ)
+    if !linear
+      nie = get_nie(elmᵢ)
+      Bie = get_Bie(elmᵢ)
+      indicesᵢ = get_indices(elmᵢ)
+      value_Bie = zeros(T, nie, nie)
+      map((i -> value_Bie[:, i] .= Bie * SparseVector(nie, [i], [1])), 1:nie)
+      spm[indicesᵢ, indicesᵢ] .+= value_Bie
+    end
   end
   return plm
 end

--- a/src/P_mat/part_mat.jl
+++ b/src/P_mat/part_mat.jl
@@ -15,7 +15,7 @@ export set_N!, set_n!, set_permutation!
 export get_eelo_set, get_ee_struct_Bie
 export set_eelo_set!
 
-export get_eelo_set, get_eelo_set, set_spm!, get_eelo_sub_set, get_eelo_set_Bie
+export get_eelo_sub_set, get_eelo_set_Bie
 export get_spm, get_L
 export set_L!, set_L_to_spm!
 

--- a/src/methods/PartitionedQuasiNewton.jl
+++ b/src/methods/PartitionedQuasiNewton.jl
@@ -60,14 +60,17 @@ function PBFGS_update!(
   N = get_N(epm_B)
   for i = 1:N
     eemi = get_eem_set(epm_B, i)
-    Bi = get_Bie(eemi)
-    si = get_vec(get_eev_set(epv_s, i))
-    yi = get_vec(get_eev_set(epv_y, i))
-    index = get_index(eemi)
-    Bs = get_Bsr(get_eem_set(epm_B, i))
-    update = BFGS!(si, yi, Bi; index = index, Bs, kwargs...) # return 0 or 1
-    cem = get_cem(eemi)
-    update_counter_elt_mat!(cem, update)
+    linear = get_linear(eemi)
+    if !linear
+      Bi = get_Bie(eemi)
+      si = get_vec(get_eev_set(epv_s, i))
+      yi = get_vec(get_eev_set(epv_y, i))
+      index = get_index(eemi)
+      Bs = get_Bsr(get_eem_set(epm_B, i))
+      update = BFGS!(si, yi, Bi; index = index, Bs, kwargs...) # return 0 or 1
+      cem = get_cem(eemi)
+      update_counter_elt_mat!(cem, update)
+    end
   end
   verbose && (str = string_counters_iter(epm_B))
   verbose && (print("\n PBFGS" * str))
@@ -122,14 +125,17 @@ function PSR1_update!(
   N = get_N(epm_B)
   for i = 1:N
     eemi = get_eem_set(epm_B, i)
-    Bi = get_Bie(eemi)
-    si = get_vec(get_eev_set(epv_s, i))
-    yi = get_vec(get_eev_set(epv_y, i))
-    r = get_Bsr(get_eem_set(epm_B, i))
-    index = get_index(eemi)
-    update = SR1!(si, yi, Bi; index = index, r, kwargs...) # return 0 or 1
-    cem = get_cem(eemi)
-    update_counter_elt_mat!(cem, update)
+    linear = get_linear(eemi)
+    if !linear
+      Bi = get_Bie(eemi)
+      si = get_vec(get_eev_set(epv_s, i))
+      yi = get_vec(get_eev_set(epv_y, i))
+      r = get_Bsr(get_eem_set(epm_B, i))
+      index = get_index(eemi)
+      update = SR1!(si, yi, Bi; index = index, r, kwargs...) # return 0 or 1
+      cem = get_cem(eemi)
+      update_counter_elt_mat!(cem, update)
+    end
   end
   verbose && (str = string_counters_iter(epm_B))
   verbose && (print("\n PSR1" * str))
@@ -185,14 +191,17 @@ function PSE_update!(
   acc = 0
   for i = 1:N
     eemi = get_eem_set(epm_B, i)
-    Bi = get_Bie(eemi)
-    si = get_vec(get_eev_set(epv_s, i))
-    yi = get_vec(get_eev_set(epv_y, i))
-    Bs_r = get_Bsr(get_eem_set(epm_B, i))
-    index = get_index(eemi)
-    update = SE!(si, yi, Bi; index = index, Bs_r, kwargs...) # return 0 or 1
-    cem = get_cem(eemi)
-    update_counter_elt_mat!(cem, update)
+    linear = get_linear(eemi)
+    if !linear
+      Bi = get_Bie(eemi)
+      si = get_vec(get_eev_set(epv_s, i))
+      yi = get_vec(get_eev_set(epv_y, i))
+      Bs_r = get_Bsr(get_eem_set(epm_B, i))
+      index = get_index(eemi)
+      update = SE!(si, yi, Bi; index = index, Bs_r, kwargs...) # return 0 or 1
+      cem = get_cem(eemi)
+      update_counter_elt_mat!(cem, update)
+    end
   end
   verbose && (str = string_counters_iter(epm_B))
   verbose && (print("\n PSE" * str))
@@ -247,18 +256,21 @@ function PCS_update!(
   N = get_N(epm_B)
   for i = 1:N
     eemi = get_eem_set(epm_B, i)
-    Bi = get_Bie(eemi)
-    si = get_vec(get_eev_set(epv_s, i))
-    yi = get_vec(get_eev_set(epv_y, i))
-    index = get_index(eemi)
-    convex = get_convex(eemi)
-    if convex
-      update = BFGS!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
-    else
-      update = SR1!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
+    linear = get_linear(eemi)
+    if !linear
+      Bi = get_Bie(eemi)
+      si = get_vec(get_eev_set(epv_s, i))
+      yi = get_vec(get_eev_set(epv_y, i))
+      index = get_index(eemi)
+      convex = get_convex(eemi)
+      if convex
+        update = BFGS!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
+      else
+        update = SR1!(si, yi, Bi; index = index, kwargs...) # return 0 or 1
+      end
+      cem = get_cem(eemi)
+      update_counter_elt_mat!(cem, update)
     end
-    cem = get_cem(eemi)
-    update_counter_elt_mat!(cem, update)
   end
   verbose && (str = string_counters_iter(epm_B))
   verbose && (print("\n PCS" * str))

--- a/test/P_mat/em.jl
+++ b/test/P_mat/em.jl
@@ -5,8 +5,8 @@ using PartitionedStructures.M_elt_mat, PartitionedStructures.ModElemental_em
   T = Float64
   nie = 5
   n = 20
-  eem1 = identity_eem(nie; T = T, n = n, bool = true)
-  eem2 = ones_eem(nie; T = T, n = n, bool = false)
+  eem1 = identity_eem(nie; T = T, n = n, convex = true)
+  eem2 = ones_eem(nie; T = T, n = n, convex = false)
   @test eem1.convex == true
   @test eem2.convex == false
 
@@ -26,7 +26,7 @@ end
   T = Float64
   nie = 5
   n = 20
-  eem = identity_eem(nie; T, n, bool = true)
+  eem = identity_eem(nie; T, n, convex = true)
 
   cpt_eem = get_counter_elt_mat(eem)
   cpt = Counter_elt_mat()
@@ -59,7 +59,7 @@ end
   T = Float64
   nie = 5
   n = 20
-  eem = identity_eem(nie; T, n, bool = true)
+  eem = identity_eem(nie; T, n, convex = true)
 
   set_nie!(eem, 6)
   @test get_nie(eem) == 6

--- a/test/P_mat/plm.jl
+++ b/test/P_mat/plm.jl
@@ -15,9 +15,10 @@ using PartitionedStructures.M_abstract_part_struct
       Bie_bfgs = LinearOperators.LBFGSOperator(T, nie)
       Bie_sr1 = LinearOperators.LSR1Operator(T, nie)
       counter = Counter_elt_mat()
-      @test Elemental_elo_bfgs{T}(nie, indices, Bie_bfgs, counter) ==
+      linear = false
+      @test Elemental_elo_bfgs{T}(nie, indices, Bie_bfgs, counter, linear) ==
             LBFGS_eelo(nie; T = T, index = index)
-      @test Elemental_elo_sr1{T}(nie, indices, Bie_sr1, counter) ==
+      @test Elemental_elo_sr1{T}(nie, indices, Bie_sr1, counter, linear) ==
             LSR1_eelo(nie; T = T, index = index)
     end
   end

--- a/test/P_mat/plm.jl
+++ b/test/P_mat/plm.jl
@@ -202,3 +202,13 @@ end
   eplosr1 = identity_eplo_LSR1(element_variables)
   @test SparseMatrixCSC(eplose) == SparseMatrixCSC(eplosr1)
 end
+
+@testset "Matrix and SparseMatrix with linear element matrices (LinearOperators)" begin
+  N = 4
+  n = 8
+  element_variables = [[1, 2, 5, 7], [3, 6, 7, 8], [2, 4, 6, 8], [1, 3, 5, 6, 7]]
+  
+  linears = [true,false,false,true]
+  B = identity_eplo_LSR1(element_variables; linear_vector=linears)
+  Matrix(B)
+end

--- a/test/P_mat/pm.jl
+++ b/test/P_mat/pm.jl
@@ -117,3 +117,13 @@ end
   a = @allocated update!(epm, epv, epv2; name = :pse, verbose = false)
   @test a == 0
 end
+
+@testset "Matrix and SparseMatrix with linear element matrices" begin
+  N = 4
+  n = 8
+  element_variables = [[1, 2, 5, 7], [3, 6, 7, 8], [2, 4, 6, 8], [1, 3, 5, 6, 7]]
+  
+  linears = [true,false,false,true]
+  B = identity_epm(element_variables; linear_vector=linears)
+  Matrix(B)
+end

--- a/test/others/link.jl
+++ b/test/others/link.jl
@@ -37,3 +37,42 @@ using PartitionedStructures.M_abstract_part_struct, PartitionedStructures.M_part
   @test string_counters_total(_epm2) ==
         "\t structure: Elemental_pm{Float64} based from 3 elements; update: 0, untouch: 0, reset: 0 \n"
 end
+
+
+@testset "mul_epm_epv with linear_vector" begin
+  N = 4
+  n = 8
+  element_variables = [[1, 2, 5, 7], [3, 6, 7, 8], [2, 4, 6, 8], [1, 3, 5, 6, 7]]
+
+  epv = PartitionedStructures.epv_from_v(ones(n), create_epv(element_variables))
+  # without linear_vectors
+  B = identity_epm(element_variables)  
+
+  res = mul_epm_epv(B, epv)
+  vres = Vector(res)
+  @test sum(vres) == 17
+  @test vres[1] == 2
+  @test vres[2] == 2
+  @test vres[3] == 2
+  @test vres[4] == 1
+  @test vres[5] == 2
+  @test vres[6] == 3
+  @test vres[7] == 3
+  @test vres[8] == 2
+
+  # with linear_vectors
+  linears = [true,false,false,true]
+  B = identity_epm(element_variables; linear_vector=linears)
+
+  res = mul_epm_epv(B, epv)
+  vres = Vector(res)
+  @test sum(vres) == 8
+  @test vres[1] == 0
+  @test vres[2] == 1
+  @test vres[3] == 1
+  @test vres[4] == 1
+  @test vres[5] == 0
+  @test vres[6] == 2
+  @test vres[7] == 1
+  @test vres[8] == 2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra: Matrix
+using LinearAlgebra
 using PartitionedStructures
 using Test
 


### PR DESCRIPTION
Add a `linear::Bool` field to element structures + propagate an optionnal argument to partitioned structures + tests and minor corrections.

Element structures having `linear=true` are stored with a `0x0` `Matrix` or `LinearOperator`.
With this modification, a linear element function merging every linear element function that may have a large subset of variables will have a memory cost almost null.
In addition, these elements will not by updated and don't contribute to `mul!`.